### PR TITLE
Added CASC, CASIC and PLA to lsp filters

### DIFF
--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -90,6 +90,9 @@ fn agency_map() -> HashMap<&'static str, &'static str> {
     res.insert("eurockot", "Eurockot Launch Services");
     res.insert("rocketlab", "Rocket Lab Ltd");
     res.insert("orbitalatk", "Orbital ATK");
+    res.insert("casc", "China Aerospace Science and Technology Corporation");
+    res.insert("casic", "China Aerospace Science and Industry Corporation");
+    res.insert("pla", "People's Liberation Army");
 
     res
 }


### PR DESCRIPTION
CASC, CASIC and PLA added to filters. These providers don't have official livestreams, so it'd be nice to filter them out of launch notifications.